### PR TITLE
BugFix in using cv::minMaxIdx()

### DIFF
--- a/src/ivtracker.cpp
+++ b/src/ivtracker.cpp
@@ -219,15 +219,16 @@ void IncrementalVisualTracker::estimateWarpCondensation(const cv::Mat& image)
     /* Store most likely particle */
     const auto normCoeff = static_cast<PRECISION>(1.0 / cv::sum(m_stateConfidences)[0]);
     cv::multiply(m_stateConfidences, normCoeff, m_stateConfidences, 1.0, CV_PRECISION);
-    double maxProb;
-    int maxProbIdx;
-    cv::minMaxIdx(m_stateConfidences, nullptr, &maxProb, nullptr, &maxProbIdx);
-    m_mostLikelyState = m_states.row(maxProbIdx).clone();
+
+    double maxProb = 0;
+    int maxProbIdx[2] = {0,0};
+    cv::minMaxIdx(m_stateConfidences, nullptr, &maxProb, nullptr, maxProbIdx);
+    m_mostLikelyState = m_states.row(maxProbIdx[1]).clone();
     m_templ.prob = maxProb;
-    const cv::Mat maxProbWimgFlatten = wimgsFlatten.col(maxProbIdx).clone();
+    const cv::Mat maxProbWimgFlatten = wimgsFlatten.col(maxProbIdx[1]).clone();
     m_mostLikelyWarpImage = maxProbWimgFlatten.reshape(0, m_templShape.width).clone();
 
-    m_warpBatch.emplace_back(maxProbWimgFlatten.clone());
+    m_warpBatch.push_back(maxProbWimgFlatten.clone());       
 }
 
 

--- a/src/ivtracker.cpp
+++ b/src/ivtracker.cpp
@@ -224,7 +224,7 @@ void IncrementalVisualTracker::estimateWarpCondensation(const cv::Mat& image)
     cv::minMaxIdx(m_stateConfidences, nullptr, &maxProb, nullptr, maxProbIdx);
     m_mostLikelyState = m_states.row(maxProbIdx[0]).clone();
     m_templ.prob = maxProb;
-    const cv::Mat maxProbWimgFlatten = wimgsFlatten.col(maxProbIdx[1]).clone();
+    const cv::Mat maxProbWimgFlatten = wimgsFlatten.col(maxProbIdx[0]).clone();
     m_mostLikelyWarpImage = maxProbWimgFlatten.reshape(0, m_templShape.width).clone();
 
     m_warpBatch.emplace_back(maxProbWimgFlatten.clone());       

--- a/src/ivtracker.cpp
+++ b/src/ivtracker.cpp
@@ -222,7 +222,7 @@ void IncrementalVisualTracker::estimateWarpCondensation(const cv::Mat& image)
     double maxProb = 0;
     int maxProbIdx[2] = {0,0};
     cv::minMaxIdx(m_stateConfidences, nullptr, &maxProb, nullptr, maxProbIdx);
-    m_mostLikelyState = m_states.row(maxProbIdx[1]).clone();
+    m_mostLikelyState = m_states.row(maxProbIdx[0]).clone();
     m_templ.prob = maxProb;
     const cv::Mat maxProbWimgFlatten = wimgsFlatten.col(maxProbIdx[1]).clone();
     m_mostLikelyWarpImage = maxProbWimgFlatten.reshape(0, m_templShape.width).clone();

--- a/src/ivtracker.cpp
+++ b/src/ivtracker.cpp
@@ -219,7 +219,6 @@ void IncrementalVisualTracker::estimateWarpCondensation(const cv::Mat& image)
     /* Store most likely particle */
     const auto normCoeff = static_cast<PRECISION>(1.0 / cv::sum(m_stateConfidences)[0]);
     cv::multiply(m_stateConfidences, normCoeff, m_stateConfidences, 1.0, CV_PRECISION);
-
     double maxProb = 0;
     int maxProbIdx[2] = {0,0};
     cv::minMaxIdx(m_stateConfidences, nullptr, &maxProb, nullptr, maxProbIdx);
@@ -228,7 +227,7 @@ void IncrementalVisualTracker::estimateWarpCondensation(const cv::Mat& image)
     const cv::Mat maxProbWimgFlatten = wimgsFlatten.col(maxProbIdx[1]).clone();
     m_mostLikelyWarpImage = maxProbWimgFlatten.reshape(0, m_templShape.width).clone();
 
-    m_warpBatch.push_back(maxProbWimgFlatten.clone());       
+    m_warpBatch.emplace_back(maxProbWimgFlatten.clone());       
 }
 
 


### PR DESCRIPTION
According to OpenCV documentation, 'maxProbIdx' must have at least 2 elements. To avoid stack corrupted, i fix it by using array of 2 elements.
`Note
When minIdx is not NULL, it must have at least 2 elements (as well as maxIdx), even if src is a single-row or single-column matrix. In OpenCV (following MATLAB) each array has at least 2 dimensions, i.e. single-column matrix is Mx1 matrix (and therefore minIdx/maxIdx will be (i1,0)/(i2,0)) and single-row matrix is 1xN matrix (and therefore minIdx/maxIdx will be (0,j1)/(0,j2)).`